### PR TITLE
enable building with GHC 9.2 by loosening package requirements

### DIFF
--- a/linux-xattr.cabal
+++ b/linux-xattr.cabal
@@ -36,6 +36,6 @@ Library
   Default-Language:    Haskell2010
   Default-Extensions:  Safe
   Build-Depends:       base == 4.*,
-                       bytestring == 0.10.*
+                       bytestring >= 0.10
   Ghc-Options:         -Wall
   Exposed-Modules:     System.Linux.XAttr


### PR DESCRIPTION
A quick patch to enable building with GHC 9.2.

Tested with GHC 8.10.7, 9.0.2, and 9.2.2.